### PR TITLE
resolve TODO use AMF3 in reader function

### DIFF
--- a/rtmplite3/flv.py
+++ b/rtmplite3/flv.py
@@ -184,7 +184,14 @@ class FLV(object):
                 # if self._debug: print 'FLV.read() length=', length, 'hdr=', hdr
                 # if hdr.type == Message.AUDIO: print 'r', hdr.type, hdr.time
                 if type == Message.DATA:  # metadata
-                    amfReader = amf.AMF0(body)  # TODO: use AMF3 if needed
+                    try:
+                        amfReader = amf.AMF0(body)
+                    except ValueError as e:
+                        print(e)
+                    else:
+                        if self._debug:
+                            print("Try to read as AMF3")
+                        amfReader = amf.AMF3(body)
                     name = amfReader.read()
                     obj = amfReader.read()
                     if self._debug:

--- a/rtmplite3/flv.py
+++ b/rtmplite3/flv.py
@@ -188,6 +188,7 @@ class FLV(object):
                         amfReader = amf.AMF0(body)
                     except ValueError as e:
                         print(e)
+                        pass
                     else:
                         if self._debug:
                             print("Try to read as AMF3")


### PR DESCRIPTION
in some case FLV has no AMF0 instead AMF3 but without Version bits.